### PR TITLE
Some UNet improvements and CrossEntropyLoss() added

### DIFF
--- a/steps/pytorch/architectures/unet.py
+++ b/steps/pytorch/architectures/unet.py
@@ -13,8 +13,10 @@ class UNet(nn.Module):
                  kernel_scale=3,
                  **kwargs):
 
-        assert conv_kernel % 2 == 1
-        assert pool_stride > 1 or pool_kernel % 2 == 1
+        assert conv_kernel % 2 == 1, "Size of convolution kernel has to be an odd number. " \
+                                     "Otherwise convolution layer will not keep image size"
+        assert pool_stride > 1 or pool_kernel % 2 == 1, "Pooling layer stride has to be greater than one or" \
+                                                        "kernel of pooling layer has to be an odd number."
         warnings.warn("Please make sure, that your input tensor's dimensions are divisible by "
                       "(pool_stride ** repeat_blocks)")
 

--- a/steps/pytorch/architectures/unet.py
+++ b/steps/pytorch/architectures/unet.py
@@ -1,13 +1,20 @@
 import torch
 import torch.nn as nn
+from .utils import get_downsample_pad, get_upsample_pad
 
 
 class UNet(nn.Module):
-    def __init__(self, conv_kernel,
-                 pool_kernel, pool_stride,
-                 repeat_blocks, n_filters,
-                 batch_norm, dropout,
-                 in_channels, **kwargs):
+    def __init__(self, conv_kernel=3,
+                 pool_kernel=3, pool_stride=2,
+                 repeat_blocks=2, n_filters=8,
+                 batch_norm=True, dropout=0.1,
+                 in_channels=3, out_channels=2,
+                 kernel_scale=3,
+                 **kwargs):
+
+        assert conv_kernel % 2 == 1
+        assert pool_stride > 1 or pool_kernel % 2 == 1
+
         super(UNet, self).__init__()
 
         self.conv_kernel = conv_kernel
@@ -18,6 +25,8 @@ class UNet(nn.Module):
         self.batch_norm = batch_norm
         self.dropout = dropout
         self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.kernel_scale = kernel_scale
 
         self.input_block = self._input_block()
         self.down_convs = self._down_convs()
@@ -44,38 +53,45 @@ class UNet(nn.Module):
 
     def _down_pools(self):
         down_pools = []
+        padding = get_downsample_pad(stride=self.pool_stride, kernel=self.pool_kernel)
         for _ in range(self.repeat_blocks):
-            down_pools.append(nn.Sequential(nn.ConstantPad2d(1, 0),
-                                            nn.MaxPool2d(kernel_size=(self.pool_kernel, self.pool_kernel),
-                                                         stride=self.pool_stride)))
+            down_pools.append(nn.MaxPool2d(kernel_size=self.pool_kernel,
+                                           stride=self.pool_stride,
+                                           padding=padding))
         return nn.ModuleList(down_pools)
 
     def _up_samples(self):
         up_samples = []
+        kernel_scale = self.kernel_scale
+        stride = self.pool_stride
+        kernel_size = kernel_scale * stride
+        padding, output_padding = get_upsample_pad(stride=stride, kernel=kernel_size)
         for i in range(self.repeat_blocks):
             in_channels = int(self.n_filters * 2 ** (i + 2))
             out_channels = int(self.n_filters * 2 ** (i + 1))
             up_samples.append(nn.ConvTranspose2d(in_channels=in_channels,
                                                  out_channels=out_channels,
-                                                 kernel_size=2,
-                                                 stride=2,
-                                                 padding=0,
-                                                 output_padding=0,
+                                                 kernel_size=kernel_size,
+                                                 stride=stride,
+                                                 padding=padding,
+                                                 output_padding=output_padding,
                                                  bias=False
                                                  ))
         return nn.ModuleList(up_samples)
 
     def _input_block(self):
+        stride = 1
+        padding = get_downsample_pad(stride=stride, kernel=self.conv_kernel)
         if self.batch_norm:
             input_block = nn.Sequential(nn.Conv2d(in_channels=self.in_channels, out_channels=self.n_filters,
                                                   kernel_size=(self.conv_kernel, self.conv_kernel),
-                                                  stride=1, padding=1),
+                                                  stride=stride, padding=padding),
                                         nn.BatchNorm2d(num_features=self.n_filters),
                                         nn.ReLU(),
 
                                         nn.Conv2d(in_channels=self.n_filters, out_channels=self.n_filters,
                                                   kernel_size=(self.conv_kernel, self.conv_kernel),
-                                                  stride=1, padding=1),
+                                                  stride=stride, padding=padding),
                                         nn.BatchNorm2d(num_features=self.n_filters),
                                         nn.ReLU(),
 
@@ -84,12 +100,12 @@ class UNet(nn.Module):
         else:
             input_block = nn.Sequential(nn.Conv2d(in_channels=self.in_channels, out_channels=self.n_filters,
                                                   kernel_size=(self.conv_kernel, self.conv_kernel),
-                                                  stride=1, padding=1),
+                                                  stride=stride, padding=padding),
                                         nn.ReLU(),
 
                                         nn.Conv2d(in_channels=self.n_filters, out_channels=self.n_filters,
                                                   kernel_size=(self.conv_kernel, self.conv_kernel),
-                                                  stride=1, padding=1),
+                                                  stride=stride, padding=padding),
                                         nn.ReLU(),
 
                                         nn.Dropout(self.dropout),
@@ -103,37 +119,39 @@ class UNet(nn.Module):
 
     def _classification_block(self):
         in_block = int(2 * self.n_filters)
+        stride = 1
+        padding = get_downsample_pad(stride=stride, kernel=self.conv_kernel)
 
         if self.batch_norm:
             classification_block = nn.Sequential(nn.Conv2d(in_channels=in_block, out_channels=self.n_filters,
                                                            kernel_size=(self.conv_kernel, self.conv_kernel),
-                                                           stride=1, padding=1),
+                                                           stride=stride, padding=padding),
                                                  nn.BatchNorm2d(num_features=self.n_filters),
                                                  nn.ReLU(),
                                                  nn.Dropout(self.dropout),
 
                                                  nn.Conv2d(in_channels=self.n_filters, out_channels=self.n_filters,
                                                            kernel_size=(self.conv_kernel, self.conv_kernel),
-                                                           stride=1, padding=1),
+                                                           stride=stride, padding=padding),
                                                  nn.BatchNorm2d(num_features=self.n_filters),
                                                  nn.ReLU(),
                                                  )
         else:
             classification_block = nn.Sequential(nn.Conv2d(in_channels=in_block, out_channels=self.n_filters,
                                                            kernel_size=(self.conv_kernel, self.conv_kernel),
-                                                           stride=1, padding=1),
+                                                           stride=stride, padding=padding),
                                                  nn.ReLU(),
                                                  nn.Dropout(self.dropout),
 
                                                  nn.Conv2d(in_channels=self.n_filters, out_channels=self.n_filters,
                                                            kernel_size=(self.conv_kernel, self.conv_kernel),
-                                                           stride=1, padding=1),
+                                                           stride=stride, padding=padding),
                                                  nn.ReLU(),
                                                  )
         return classification_block
 
     def _output_layer(self):
-        return nn.Conv2d(in_channels=self.n_filters, out_channels=1,
+        return nn.Conv2d(in_channels=self.n_filters, out_channels=self.out_channels,
                          kernel_size=(1, 1), stride=1, padding=0)
 
     def forward(self, x):
@@ -169,6 +187,7 @@ class UNetMultitask(UNet):
                  batch_norm,
                  dropout,
                  in_channels,
+                 out_channels,
                  nr_outputs):
         super(UNetMultitask, self).__init__(conv_kernel,
                                             pool_kernel,
@@ -177,7 +196,8 @@ class UNetMultitask(UNet):
                                             n_filters,
                                             batch_norm,
                                             dropout,
-                                            in_channels)
+                                            in_channels,
+                                            out_channels)
         self.nr_outputs = nr_outputs
         output_legs = []
         for i in range(self.nr_outputs):
@@ -220,16 +240,18 @@ class DownConv(nn.Module):
         self.down_conv = self._down_conv()
 
     def _down_conv(self):
+        stride = 1
+        padding = get_downsample_pad(stride=stride, kernel=self.kernel_size)
         if self.batch_norm:
             down_conv = nn.Sequential(nn.Conv2d(in_channels=self.in_channels, out_channels=self.block_channels,
                                                 kernel_size=(self.kernel_size, self.kernel_size),
-                                                stride=1, padding=1),
+                                                stride=stride, padding=padding),
                                       nn.BatchNorm2d(num_features=self.block_channels),
                                       nn.ReLU(),
 
                                       nn.Conv2d(in_channels=self.block_channels, out_channels=self.block_channels,
                                                 kernel_size=(self.kernel_size, self.kernel_size),
-                                                stride=1, padding=1),
+                                                stride=stride, padding=padding),
                                       nn.BatchNorm2d(num_features=self.block_channels),
                                       nn.ReLU(),
 
@@ -238,12 +260,12 @@ class DownConv(nn.Module):
         else:
             down_conv = nn.Sequential(nn.Conv2d(in_channels=self.in_channels, out_channels=self.block_channels,
                                                 kernel_size=(self.kernel_size, self.kernel_size),
-                                                stride=1, padding=1),
+                                                stride=stride, padding=padding),
                                       nn.ReLU(),
 
                                       nn.Conv2d(in_channels=self.block_channels, out_channels=self.block_channels,
                                                 kernel_size=(self.kernel_size, self.kernel_size),
-                                                stride=1, padding=1),
+                                                stride=stride, padding=padding),
                                       nn.ReLU(),
 
                                       nn.Dropout(self.dropout),
@@ -266,17 +288,19 @@ class UpConv(nn.Module):
         self.up_conv = self._up_conv()
 
     def _up_conv(self):
+        stride = 1
+        padding = get_downsample_pad(stride=stride, kernel=self.kernel_size)
         if self.batch_norm:
             up_conv = nn.Sequential(nn.Conv2d(in_channels=self.in_channels, out_channels=self.block_channels,
                                               kernel_size=(self.kernel_size, self.kernel_size),
-                                              stride=1, padding=1),
+                                              stride=stride, padding=padding),
 
                                     nn.BatchNorm2d(num_features=self.block_channels),
                                     nn.ReLU(),
 
                                     nn.Conv2d(in_channels=self.block_channels, out_channels=self.block_channels,
                                               kernel_size=(self.kernel_size, self.kernel_size),
-                                              stride=1, padding=1),
+                                              stride=stride, padding=padding),
                                     nn.BatchNorm2d(num_features=self.block_channels),
                                     nn.ReLU(),
 
@@ -285,12 +309,12 @@ class UpConv(nn.Module):
         else:
             up_conv = nn.Sequential(nn.Conv2d(in_channels=self.in_channels, out_channels=self.block_channels,
                                               kernel_size=(self.kernel_size, self.kernel_size),
-                                              stride=1, padding=1),
+                                              stride=stride, padding=padding),
                                     nn.ReLU(),
 
                                     nn.Conv2d(in_channels=self.block_channels, out_channels=self.block_channels,
                                               kernel_size=(self.kernel_size, self.kernel_size),
-                                              stride=1, padding=1),
+                                              stride=stride, padding=padding),
                                     nn.ReLU(),
 
                                     nn.Dropout(self.dropout)

--- a/steps/pytorch/architectures/unet.py
+++ b/steps/pytorch/architectures/unet.py
@@ -23,6 +23,7 @@ class UNet(nn.Module):
         super(UNet, self).__init__()
 
         self.conv_kernel = conv_kernel
+        self.conv_stride = 1
         self.pool_kernel = pool_kernel
         self.pool_stride = pool_stride
         self.repeat_blocks = repeat_blocks
@@ -85,7 +86,7 @@ class UNet(nn.Module):
         return nn.ModuleList(up_samples)
 
     def _input_block(self):
-        stride = 1
+        stride = self.conv_stride
         padding = get_downsample_pad(stride=stride, kernel=self.conv_kernel)
         if self.batch_norm:
             input_block = nn.Sequential(nn.Conv2d(in_channels=self.in_channels, out_channels=self.n_filters,
@@ -124,7 +125,7 @@ class UNet(nn.Module):
 
     def _classification_block(self):
         in_block = int(2 * self.n_filters)
-        stride = 1
+        stride = self.conv_stride
         padding = get_downsample_pad(stride=stride, kernel=self.conv_kernel)
 
         if self.batch_norm:
@@ -245,7 +246,7 @@ class DownConv(nn.Module):
         self.down_conv = self._down_conv()
 
     def _down_conv(self):
-        stride = 1
+        stride = self.conv_stride
         padding = get_downsample_pad(stride=stride, kernel=self.kernel_size)
         if self.batch_norm:
             down_conv = nn.Sequential(nn.Conv2d(in_channels=self.in_channels, out_channels=self.block_channels,
@@ -293,7 +294,7 @@ class UpConv(nn.Module):
         self.up_conv = self._up_conv()
 
     def _up_conv(self):
-        stride = 1
+        stride = self.conv_stride
         padding = get_downsample_pad(stride=stride, kernel=self.kernel_size)
         if self.batch_norm:
             up_conv = nn.Sequential(nn.Conv2d(in_channels=self.in_channels, out_channels=self.block_channels,

--- a/steps/pytorch/architectures/unet.py
+++ b/steps/pytorch/architectures/unet.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 from .utils import get_downsample_pad, get_upsample_pad
+import warnings
 
 
 class UNet(nn.Module):
@@ -14,6 +15,8 @@ class UNet(nn.Module):
 
         assert conv_kernel % 2 == 1
         assert pool_stride > 1 or pool_kernel % 2 == 1
+        warnings.warn("Please make sure, that your input tensor's dimensions are divisible by "
+                      "(pool_stride ** repeat_blocks)")
 
         super(UNet, self).__init__()
 

--- a/steps/pytorch/architectures/utils.py
+++ b/steps/pytorch/architectures/utils.py
@@ -1,4 +1,6 @@
 import torch.nn as nn
+import math
+
 
 class Reshape(nn.Module):
     def __init__(self, *shape):
@@ -7,3 +9,16 @@ class Reshape(nn.Module):
 
     def forward(self, x):
         return x.view(*self.shape)
+
+
+def get_downsample_pad(stride, kernel, dilation=1):
+    return int(math.ceil((1 - stride + dilation * kernel - 1) / 2))
+
+
+def get_upsample_pad(stride, kernel, dilation=1):
+    if kernel - stride >= 0 and (kernel - stride) % 2 == 0:
+        return (int((kernel - stride) / 2), 0)
+    elif kernel - stride < 0:
+        return (0, stride - kernel)
+    else:
+        return (int(math.ceil((kernel - stride) / 2)), 1)

--- a/steps/pytorch/validation.py
+++ b/steps/pytorch/validation.py
@@ -93,3 +93,8 @@ def torch_acc_score_multi_output(outputs, targets, take_first=None):
         accuracies.append(accuracy)
     avg_accuracy = sum(accuracies) / len(accuracies)
     return avg_accuracy
+
+
+def multiclass_segmentation_loss(output, target):
+    cross_entropy = nn.CrossEntropyLoss()
+    return cross_entropy(output, target)


### PR DESCRIPTION
UNet has now this nice property, that after each pooling or Conv2d layer the output tensor has dimensions:
H_out = H_in/stride
W_out = W_in/stride
Also after each ConvTranspose2d layer output tensor has dimensions:
H_out = H_in * stride
W_out = W_in * stride
User has to take care for dimensions of the tensor to be divisible by stride.

Also CrossEntropyLoss for multi-channel tensor was added.